### PR TITLE
Update Request for DNS Made Easy DDNS Client

### DIFF
--- a/src/com/esotericsoftware/dnsmadeeasy/DnsMadeEasy.java
+++ b/src/com/esotericsoftware/dnsmadeeasy/DnsMadeEasy.java
@@ -44,14 +44,14 @@ public class DnsMadeEasy {
 	void update (String user, String pass, String id) throws IOException {
 		String newIP;
 		try {
-			newIP = http("http://www.dnsmadeeasy.com/myip.jsp");
+			newIP = http("http://myip.dnsmadeeasy.com");
 		} catch (IOException ex) {
 			log("Error obtaining IP.", ex);
 			return;
 		}
 		if (newIP.equals(lastIP)) return;
 
-		String result = http("http://www.dnsmadeeasy.com/servlet/updateip?username=" + user + "&password=" + pass + "&id=" + id
+		String result = http("http://cp.dnsmadeeasy.com/servlet/updateip?username=" + user + "&password=" + pass + "&id=" + id
 			+ "&ip=" + newIP);
 		log(newIP + ", " + result, null);
 		if (result.equals("success")) {


### PR DESCRIPTION
On August 1st 2015 DNS Made Easy will be changing the url for update calls to http://cp.dnsmadeeasy.com/servlet/updateip? 
In addition the url to grab the IP will change to http://myip.dnsmadeeasy.com

Here is a link to the new documentation: http://www.dnsmadeeasy.com/dynamic-dns/
